### PR TITLE
Set routing key to None in eiffellib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ graphql-core==2.2.1
 gql==0.1.0
 cryptography==3.1
 redis==3.5.3
-eiffellib==1.2.0
+eiffellib[rabbitmq]==2.2.0
 pydantic==1.6
 python-box==5.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     gql==0.1.0
     cryptography==3.1
     redis==3.5.3
-    eiffellib==1.2.0
+    eiffellib[rabbitmq]==2.2.0
     pydantic==1.6
     requests==2.24.0
     kubernetes==7.0.1

--- a/src/etos_lib/etos.py
+++ b/src/etos_lib/etos.py
@@ -49,9 +49,12 @@ class ETOS:  # pylint: disable=too-many-instance-attributes
     __secrets = None
     __database = None
 
-    def __init__(self, service_name, host, name):
+    def __init__(self, service_name, host, name, domain_id=None):
         """Initialize source and service name."""
-        self.config.set("source", {"name": name, "host": host})
+        source = {"name": name, "host": host}
+        if domain_id is not None:
+            source["domainId"] = domain_id
+        self.config.set("source", source)
         self.config.set("service_name", service_name)
 
     def __del__(self):
@@ -64,7 +67,7 @@ class ETOS:  # pylint: disable=too-many-instance-attributes
         rabbitmq = self.config.get("rabbitmq_publisher")
         if not rabbitmq:
             raise PublisherConfigurationMissing
-        self.publisher = RabbitMQPublisher(**rabbitmq)
+        self.publisher = RabbitMQPublisher(routing_key=None, **rabbitmq)
         if not self.debug.disable_sending_events:
             self.publisher.start()
         self.config.set("publisher", self.publisher)

--- a/src/etos_lib/lib/config.py
+++ b/src/etos_lib/lib/config.py
@@ -96,7 +96,10 @@ class Config:
         """Load RabbitMQ subscriber data from environment variables and set in config."""
         if not self.get("rabbitmq"):
             self.rabbitmq_from_environment()
-        data = {"queue": os.getenv("RABBITMQ_QUEUE", None), "routing_key": "#"}
+        data = {
+            "queue": os.getenv("RABBITMQ_QUEUE", None),
+            "routing_key": os.getenv("RABBITMQ_ROUTING_KEY", "#")
+        }
         data.update(**self.get("rabbitmq").copy())
         self.set("rabbitmq_subscriber", data)
 


### PR DESCRIPTION

<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
N/A

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Update to latest eiffellib and set routing_key to None.
Also add an optional domain_id to constructor.
This change cannot be merged until eiffel-community/eiffel-pythonlib#37 is merged

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
Eiffellib updated, we should always follow eiffellib. No other alternative was considered.

### Benefits
<!-- What benefits will be realized by the change? -->
This change adds routing keys to events.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
None

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
