### PR TITLE
Add ability to set routing key tag via environment variables

### DIFF
--- a/src/etos_lib/lib/debug.py
+++ b/src/etos_lib/lib/debug.py
@@ -48,6 +48,11 @@ class Debug:
         return path
 
     @property
+    def routing_key_tag(self):
+        """Tag to use for routing key on events sent by ETOS library."""
+        return os.getenv("ETOS_ROUTING_KEY_TAG", "_")
+
+    @property
     def disable_sending_events(self):
         """Disable sending eiffel events."""
         return bool(os.getenv("ETOS_DISABLE_SENDING_EVENTS", None))

--- a/src/etos_lib/lib/events.py
+++ b/src/etos_lib/lib/events.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Axis Communications AB.
+# Copyright 2020-2021 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #

--- a/src/etos_lib/lib/events.py
+++ b/src/etos_lib/lib/events.py
@@ -67,6 +67,7 @@ class Events:
             event.data.add(key, value)
         event.validate()
         self.debug.events_published.append(event)
+        event.tag = self.debug.routing_key_tag
         if not self.debug.disable_sending_events:
             self.publisher.send_event(event)
         return event


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
fixes: eiffel-community/etos#88

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Added the ability to set which tag to use in routing keys for events sent in ETOS.
I added the parameter to the debug module which is deprecated, but it is still the best place for these variables in order to follow a common structure.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
I decided against adding all of the parameters in a routing key since I feel that the "tag" is the only field that we want to modify

### Benefits
<!-- What benefits will be realized by the change? -->
This change allows us to run ETOS development in a production environment by separating out the routing keys for each deployment.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
Can be unclear why suite starter did not trigger if routing key tags are set

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
