### PR TITLE
Rabbitmq logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ __pycache__/*
 .*.swp
 */.ipynb_checkpoints/*
 .DS_Store
+.tags
 
 # Project files
 .ropeproject

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ graphql-core==2.2.1
 gql==0.1.0
 cryptography==3.1
 redis==3.5.3
-eiffellib[rabbitmq]==2.3.0
+eiffellib[rabbitmq]==2.4.1
 pydantic==1.6
 python-box==5.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     gql==0.1.0
     cryptography==3.1
     redis==3.5.3
-    eiffellib[rabbitmq]==2.3.0
+    eiffellib[rabbitmq]==2.4.1
     pydantic==1.6
     requests==2.24.0
     kubernetes==7.0.1

--- a/src/etos_lib/lib/config.py
+++ b/src/etos_lib/lib/config.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 Axis Communications AB.
+# Copyright Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -78,6 +78,19 @@ class Config:
     def rabbitmq_subscriber(self):
         """Rabbitmq Subscriber data."""
         return self.config.get("rabbitmq_subscriber")
+
+    def etos_rabbitmq_publisher_data(self):
+        """Get RabbitMQ parameters for the ETOS rabbitmq service."""
+        ssl = os.getenv("ETOS_RABBITMQ_SSL", "true") == "true"
+        return {
+            "host": os.getenv("ETOS_RABBITMQ_HOST", "127.0.0.1"),
+            "exchange": os.getenv("ETOS_RABBITMQ_EXCHANGE", "etos"),
+            "username": os.getenv("ETOS_RABBITMQ_USERNAME", None),
+            "password": os.getenv("ETOS_RABBITMQ_PASSWORD", None),
+            "port": int(os.getenv("ETOS_RABBITMQ_PORT", "5672")),
+            "vhost": os.getenv("ETOS_RABBITMQ_VHOST", None),
+            "ssl": ssl,
+        }
 
     def rabbitmq_from_environment(self):
         """Load RabbitMQ data from environment variables."""

--- a/src/etos_lib/logging/log_publisher.py
+++ b/src/etos_lib/logging/log_publisher.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 Axis Communications AB.
+# Copyright Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #

--- a/src/etos_lib/logging/log_publisher.py
+++ b/src/etos_lib/logging/log_publisher.py
@@ -1,0 +1,54 @@
+# Copyright 2020-2021 Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""ETOS rabbitmq log publisher."""
+import time
+import json
+import pika
+
+from eiffellib.publishers import RabbitMQPublisher
+
+
+class RabbitMQLogPublisher(RabbitMQPublisher):
+    """A RabbitMQ publisher that can send JSON strings instead of Eiffel events."""
+
+    def send_event(self, event, block=True, routing_key="#"):
+        """Overload the send_event from the eiffellib rabbitmq publisher to send strings.
+
+        This method differs slightly from its parent in that it takes the routing_key as input.
+        """
+        if block:
+            self.wait_start()
+            while self._channel is None or not self._channel.is_open:
+                time.sleep(0.1)
+        properties = pika.BasicProperties(
+            content_type="application/json", delivery_mode=2
+        )
+        if not isinstance(event, str):
+            event = json.dumps(event)
+
+        with self._lock:
+            try:
+                self._channel.basic_publish(
+                    self.exchange,
+                    routing_key,
+                    event,
+                    properties,
+                )
+            except:  # pylint:disable=bare-except
+                self._nacked_deliveries.append(event)
+                return
+            self._delivered += 1
+            self._deliveries[self._delivered] = event

--- a/src/etos_lib/logging/rabbitmq_handler.py
+++ b/src/etos_lib/logging/rabbitmq_handler.py
@@ -1,0 +1,65 @@
+# Copyright Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""ETOS rabbitmq handler."""
+import json
+import logging
+
+
+class RabbitMQHandler(logging.StreamHandler):
+    """A RabbitMQ log handler that sends logs tagged with user_log to RabbitMQ.
+
+    Example::
+
+        import logging
+        from uuid import uuid4
+        from etos_lib.logging.logger import setup_logging, FORMAT_CONFIG
+
+        FORMAT_CONFIG.identifier = str(uuid4())
+        setup_logging("myApp", "1.0.0", "production")
+        logger = logging.getLogger(__name__)
+        logger.info("Hello!", extra={"user_log": True})
+    """
+
+    closing = False
+
+    def __init__(self, rabbitmq):
+        """Initialize."""
+        super().__init__()
+        self.rabbitmq = rabbitmq
+
+    def emit(self, record):
+        """Send user log to RabbitMQ, starting the connection if necessary.
+
+        The record parameter "user_log" must be set to True if a message shall be
+        sent to RabbitMQ.
+        """
+        if self.closing:
+            return
+
+        try:
+            send = record.user_log
+        except AttributeError:
+            send = False
+
+        msg = self.format(record)
+        try:
+            routing_key = record.routing_key
+        except AttributeError:
+            routing_key = json.loads(msg).get("identifier", "#")
+            if routing_key == "Unknown":
+                routing_key = "#"
+        if send and self.rabbitmq.is_alive():
+            self.rabbitmq.send_event(msg, routing_key=routing_key)

--- a/src/etos_lib/logging/rabbitmq_handler.py
+++ b/src/etos_lib/logging/rabbitmq_handler.py
@@ -61,8 +61,8 @@ class RabbitMQHandler(logging.StreamHandler):
             identifier = json.loads(msg).get("identifier", "Unknown")
         # An unknown identifier will never be picked up by user log handler
         # so it is unnecessary to send it.
-        if identifier == "Unknown":
-            raise ValueError("Trying to send a user log when identifier is not set")
         routing_key = f"{identifier}.log.{record.levelname}"
         if send and self.rabbitmq.is_alive():
+            if identifier == "Unknown":
+                raise ValueError("Trying to send a user log when identifier is not set")
             self.rabbitmq.send_event(msg, routing_key=routing_key)


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
based on #18 
eiffel-community/etos#148

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Add so that the ETOS library will send logs to another RabbitMQ exchange for other services to consume.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
I made it so that the new RabbitMQ exchange is required. This is because we want ETOS client to rely on this information in order to print more user-focused information.

### Benefits
<!-- What benefits will be realized by the change? -->
This will allow ETOS to communicate back user logs to the ETOS client in a structured way.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
Possible flakiness due to using another RabbitMQ publisher in all ETOS services, but we are using the eiffellib RabbitMQ publisher design which is extremely stable so I don't see this as a major problem.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
