### PR TITLE
Disable sending logs

### DIFF
--- a/src/etos_lib/lib/debug.py
+++ b/src/etos_lib/lib/debug.py
@@ -53,9 +53,9 @@ class Debug:
         return bool(os.getenv("ETOS_DISABLE_SENDING_EVENTS", None))
 
     @property
-    def disable_sending_logs(self):
+    def enable_sending_logs(self):
         """Disable sending eiffel events."""
-        return bool(os.getenv("ETOS_DISABLE_SENDING_LOGS", None))
+        return bool(os.getenv("ETOS_ENABLE_SENDING_LOGS", None))
 
     @property
     def disable_receiving_events(self):

--- a/src/etos_lib/lib/debug.py
+++ b/src/etos_lib/lib/debug.py
@@ -53,6 +53,11 @@ class Debug:
         return bool(os.getenv("ETOS_DISABLE_SENDING_EVENTS", None))
 
     @property
+    def disable_sending_logs(self):
+        """Disable sending eiffel events."""
+        return bool(os.getenv("ETOS_DISABLE_SENDING_LOGS", None))
+
+    @property
     def disable_receiving_events(self):
         """Disable receiving eiffel events."""
         return bool(os.getenv("ETOS_DISABLE_RECEIVING_EVENTS", None))

--- a/src/etos_lib/logging/logger.py
+++ b/src/etos_lib/logging/logger.py
@@ -139,7 +139,7 @@ def setup_rabbitmq_logging(log_filter):
     rabbitmq = RabbitMQLogPublisher(
         **Config().etos_rabbitmq_publisher_data(), routing_key=None
     )
-    if not Debug().disable_sending_logs:
+    if Debug().enable_sending_logs:
         rabbitmq.start()
         atexit.register(close_rabbit, rabbitmq)
 

--- a/src/etos_lib/logging/logger.py
+++ b/src/etos_lib/logging/logger.py
@@ -139,9 +139,9 @@ def setup_rabbitmq_logging(log_filter):
     rabbitmq = RabbitMQLogPublisher(
         **Config().etos_rabbitmq_publisher_data(), routing_key=None
     )
-    if not Debug().disable_sending_events:
+    if not Debug().disable_sending_logs:
         rabbitmq.start()
-    atexit.register(close_rabbit, rabbitmq)
+        atexit.register(close_rabbit, rabbitmq)
 
     rabbit_handler = RabbitMQHandler(rabbitmq)
     rabbit_handler.setFormatter(EtosLogFormatter())


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
Based on: #20 

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Some services, like the ETOS API, do not benefit from sending logs to RabbitMQ as they are run too early for the ESR to pick them up.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
We did have the "disable_sending_events" flag before, but some services do still need to publish events while not publishing logs so this added flag will allow for that.

### Benefits
<!-- What benefits will be realized by the change? -->
Services that require the sending of events but not logs can control the flow.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
None

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- <Your full name> <your-email@example.org> -->
