### PR TITLE
Set default log sending to true

### DIFF
--- a/src/etos_lib/lib/debug.py
+++ b/src/etos_lib/lib/debug.py
@@ -54,8 +54,8 @@ class Debug:
 
     @property
     def enable_sending_logs(self):
-        """Disable sending eiffel events."""
-        return bool(os.getenv("ETOS_ENABLE_SENDING_LOGS", None))
+        """Enable sending ETOS log events."""
+        return os.getenv("ETOS_ENABLE_SENDING_LOGS", "true").lower() == "true"
 
     @property
     def disable_receiving_events(self):


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
None

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Set the default to true when sending logs to RabbitMQ

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
The current design where the default is False works pretty well when upgrading ETOS Library to services that don't need to send logs to RabbitMQ, but the problem is that we are going to design ETOS to work with these logs by default so having the default be False just does not make sense.
I had too much tunnelvision in #21  to see this.

### Benefits
<!-- What benefits will be realized by the change? -->
This will enable the log sending on all services by default

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
This will enable the log sending on all services by default, even those that don't need it. They will need to disable it by setting "ETOS_ENABLE_SENDING_LOGS=false"

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
