### PR TITLE
Replace the wait_for functionality in lib/http

### DIFF
--- a/src/etos_lib/lib/http.py
+++ b/src/etos_lib/lib/http.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 Axis Communications AB.
+# Copyright Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -14,108 +14,74 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """ETOS Library HTTP Client."""
-from json.decoder import JSONDecodeError
-import logging
-import time
-import traceback
-from urllib3.exceptions import MaxRetryError, NewConnectionError
 import requests
-from requests.exceptions import HTTPError
+from requests.adapters import HTTPAdapter
+from urllib3.util import Retry
+
 from .debug import Debug
+
+DEFAULT_RETRY = Retry(
+    total=None,
+    read=0,
+    connect=10,  # With 1 as backoff_factor, will retry for 1023s
+    status=10,  # With 1 as backoff_factor, will retry for 1023s
+    backoff_factor=1,
+    other=0,
+    status_forcelist=Retry.RETRY_AFTER_STATUS_CODES,  # 413, 429, 503
+)
+
+
+class TimeoutHTTPAdapter(HTTPAdapter):
+    """Adapter for automatically setting the default timeout on requests."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize timeout with default timeout set."""
+        self.timeout = kwargs.get("timeout", Debug().default_http_timeout)
+        if "timeout" in kwargs:
+            del kwargs["timeout"]
+        super().__init__(*args, **kwargs)
+
+    def send(self, request, timeout=None, **kwargs):  # pylint:disable=arguments-differ
+        """Set timeout if provided or add the default timeout when sending request."""
+        if timeout is None:
+            timeout = self.timeout
+        return super().send(request, timeout=timeout, **kwargs)
 
 
 class Http:
     """Utility class for HTTP requests."""
 
-    logger = logging.getLogger("HTTP")
-
-    def __init__(self):
-        """Initialize a debug instance."""
+    def __init__(self, retry: Retry = DEFAULT_RETRY, timeout=None):
+        """Initialize a requests session and set default retry adapter."""
         self.debug = Debug()
-
-    @staticmethod
-    def request(verb, url, as_json=True, **requests_kwargs):
-        """Make an HTTP request.
-
-        :param verb: Which HTTP verb to use. GET, PUT, POST
-                     (DELETE omitted)
-        :type verb: str
-        :param as_json: Whether or not to return json instead of response.
-        :type as_json: bool
-        :param request_kwargs: Keyword arguments for the requests command.
-        :type request_kwargs: dict
-        :return: HTTP response or json.
-        :rtype: Response or dict
-        """
-        request = None
-        if verb.lower() == "put":
-            request = requests.put
-        elif verb.lower() == "post":
-            request = requests.post
-        elif verb.lower() == "get":
-            request = requests.get
-        response = request(url, **requests_kwargs)
-        response.raise_for_status()
-        if as_json:
-            return response.json()
-        return response
-
-    def retry(self, verb, url, timeout=None, as_json=True, **requests_kwargs):
-        """Attempt to connect to url for x time.
-
-        :param verb: Which HTTP verb to use. GET, PUT, POST
-                     (DELETE omitted)
-        :type verb: str
-        :param timeout: How long, in seconds, to retry request.
-        :type timeout: int or None
-        :param as_json: Whether or not to return json instead of response.
-        :type as_json: bool
-        :param request_kwargs: Keyword arguments for the requests command.
-        :type request_kwargs: dict
-        :return: HTTP response or json.
-        :rtype: Response or dict
-        """
         if timeout is None:
             timeout = self.debug.default_http_timeout
-        end_time = time.time() + timeout
-        self.logger.debug(
-            "Retrying URL %s for %d seconds with a %s request.", url, timeout, verb
-        )
-        iteration = 0
-        while time.time() < end_time:
-            iteration += 1
-            self.logger.debug("Iteration: %d", iteration)
-            try:
-                yield self.request(verb, url, as_json, **requests_kwargs)
-                break
-            except (
-                ConnectionError,
-                HTTPError,
-                NewConnectionError,
-                MaxRetryError,
-                TimeoutError,
-                JSONDecodeError,
-            ):
-                traceback.print_exc()
-                time.sleep(2)
-        else:
-            raise ConnectionError(
-                f"Unable to {verb} {url} with params {requests_kwargs}"
-            )
 
-    def wait_for_request(self, uri, timeout=None, as_json=True, **params):
-        """Request a URI with parameters until it succeeds.
+        self.__session = requests.Session()
+        self.adapter = TimeoutHTTPAdapter(max_retries=retry, timeout=timeout)
+        self.__session.mount("https://", self.adapter)
+        self.__session.mount("http://", self.adapter)
 
-        :param uri: URI to request.
-        :type uri: str
-        :param timeout: How long, in seconds, to attempt request.
-        :type timeout: int
-        :param as_json: Whether the response is json or not.
-        :type as_json: bool
-        :param params: Parameters for the request.
-        :type params: dict
-        :return: HTTP response or json.
-        :rtype: Response or dict
-        """
-        self.logger.info("Requesting '%s' with parameters '%s'", uri, params)
-        return self.retry("GET", uri, timeout, as_json, **params)
+    def get(self, url, params=None, **kwargs):
+        """HTTP GET requests via requests session."""
+        return self.__session.get(url, params=params, **kwargs)
+
+    def head(self, url, **kwargs):
+        """HTTP HEAD requests via requests session."""
+        return self.__session.head(url, **kwargs)
+
+    def put(self, url, data=None, **kwargs):
+        """HTTP PUT requests via requests session."""
+        return self.__session.put(url, data=data, **kwargs)
+
+    def post(self, url, data=None, json=None, **kwargs):
+        """HTTP POST requests via requests session."""
+        return self.__session.post(url, data=data, json=json, **kwargs)
+
+    def patch(self, url, data=None, **kwargs):
+        """HTTP PATCH requests via requests session."""
+        return self.__session.patch(url, data=data, **kwargs)
+
+    def delete(self, url, **kwargs):
+        """HTTP DELETE requests via requests session."""
+        return self.__session.delete(url, **kwargs)


### PR DESCRIPTION


<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
None

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
The old implementation is too inflexible and causes a lot of headaches. With this new one we will only retry on certain errors and exit early otherwise.
The new system is also much more configurable with the use of urllib3 Retry helper so that each component can decide on their own retry strategy.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
I thought about just letting each service decide on their own as the duplicated code is not that massive. However with the way this implementation works I am not afraid that we'll get into the same situation that we have now.

### Benefits
<!-- What benefits will be realized by the change? -->
Allows us to exit early if there are unrecoverable errors and also allows the applications to decide themselves how their retry strategies should be.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
This is not a backwards-compatible change. Decided against adding deprecated versions of the old methods since it would just keep us using the old, bad, way of doing this.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
