### PR TITLE
fix return type in common.py:_flatten()

### DIFF
--- a/src/etos_lib/eiffel/common.py
+++ b/src/etos_lib/eiffel/common.py
@@ -71,7 +71,7 @@ def add_span_eiffel_attributes(span: Span, event: EiffelBaseEvent) -> None:
     span.set_attribute(SpanAttributes.MESSAGING_MESSAGE_ID, event.meta.event_id)
 
 
-def _flatten(d: dict, parent_key: str = "", sep: str = ".") -> Iterable[str, str]:
+def _flatten(d: dict, parent_key: str = "", sep: str = ".") -> Iterable[tuple[str, str]]:
     """Flatten a dictionary to be compatible with opentelemetry."""
     for k, v in d.items():
         new_key = parent_key + sep + k if parent_key else k


### PR DESCRIPTION
### Applicable Issues

### Description of the Change

This change fixes the return typehint in the _flatten() function in common.py.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andreimu@axis.com