### PR TITLE
Add consts for OpenTelemetry semantic conventions

### DIFF
--- a/src/etos_lib/opentelemetry/__init__.py
+++ b/src/etos_lib/opentelemetry/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2020 Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""ETOS OpenTelemetry module."""

--- a/src/etos_lib/opentelemetry/semconv.py
+++ b/src/etos_lib/opentelemetry/semconv.py
@@ -21,26 +21,17 @@ class Attributes:
     # General ETOS conventions
     SUITE_ID = "etos.suite.id"
     SUBSUITE_ID = "etos.subsuite.id"
+    TESTRUN_ID = "etos.testrun.id"
 
     # Testrunner conentions
-    TESTRUN_ID = "etos.testrun.id"
     TESTRUNNER_ID = "etos.testrunner.id"
-    TESTRUNNER_EXCEPTION = "etos.testrunner.exception"
 
     # Environment generic conventions
-    ENVIRONMENT = "etos.environment"  # environment description as JSON
+    ENVIRONMENT = "etos.subsuite.environment"  # environment description as JSON
     ENVIRONMENT_ID = "etos.environment.id"
-    ENVIRONMENT_EXCEPTION = "etos.environment.exception"
-    ENVIRONMENT_REQUEST = "etos.environment.request"
-    ENVIRONMENT_RESPONSE = "etos.environment.response"
 
     # Execution space conventions
-    EXECUTION_SPACE = "etos.environment.execution_space"
     EXECUTOR_ID = "etos.environment.execution_space.executor.id"
 
     # IUT conventions
-    IUT = "etos.environment.iut"
     IUT_DESCRIPTION = "etos.environment.iut.description" 
-
-    # Log area conventions
-    LOG_AREA = "etos.environment.log_area"

--- a/src/etos_lib/opentelemetry/semconv.py
+++ b/src/etos_lib/opentelemetry/semconv.py
@@ -14,7 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """ETOS OpenTelemetry semantic conventions module."""
+from dataclasses import dataclass
 
+
+@dataclass(frozen=True)
 class Attributes:
     """Constants for ETOS OpenTelemetry semantic conventions."""
 
@@ -37,4 +40,4 @@ class Attributes:
     EXECUTOR_ID = "etos.environment.execution_space.executor.id"
 
     # IUT conventions
-    IUT_DESCRIPTION = "etos.environment.iut.description" 
+    IUT_DESCRIPTION = "etos.environment.iut.description"

--- a/src/etos_lib/opentelemetry/semconv.py
+++ b/src/etos_lib/opentelemetry/semconv.py
@@ -23,8 +23,11 @@ class Attributes:
     SUBSUITE_ID = "etos.subsuite.id"
     TESTRUN_ID = "etos.testrun.id"
 
-    # Testrunner conentions
-    TESTRUNNER_ID = "etos.testrunner.id"
+    # Test Runner conventions
+    TEST_RUNNER_ID = "etos.test_runner.id"
+
+    # Suite Runner conventions
+    SUITE_RUNNER_JOB_ID = "etos.suite_runner.job.id"
 
     # Environment generic conventions
     ENVIRONMENT = "etos.subsuite.environment"  # environment description as JSON

--- a/src/etos_lib/opentelemetry/semconv.py
+++ b/src/etos_lib/opentelemetry/semconv.py
@@ -1,0 +1,45 @@
+# Copyright 2020 Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""ETOS OpenTelemetry semantic conventions module."""
+
+class Attributes:
+    """Constants for ETOS OpenTelemetry semantic conventions."""
+
+    # General ETOS conventions
+    SUITE_ID = "etos.suite.id"
+    SUBSUITE_ID = "etos.subsuite.id"
+
+    # Testrunner conentions
+    TESTRUN_ID = "etos.testrun.id"
+    TESTRUNNER_ID = "etos.testrunner.id"
+    TESTRUNNER_EXCEPTION = "etos.testrunner.exception"
+
+    # Environment generic conventions
+    ENVIRONMENT_ID = "etos.environment.id"
+    ENVIRONMENT_EXCEPTION = "etos.environment.exception"
+    ENVIRONMENT_REQUEST = "etos.environment.request"
+    ENVIRONMENT_RESPONSE = "etos.environment.response"
+
+    # Execution space conventions
+    EXECUTION_SPACE = "etos.environment.execution_space"
+    EXECUTOR_ID = "etos.environment.execution_space.executor.id"
+
+    # IUT conventions
+    IUT = "etos.environment.iut"
+    IUT_DESCRIPTION = "etos.environment.iut.description" 
+
+    # Log area conventions
+    LOG_AREA = "etos.environment.log_area"

--- a/src/etos_lib/opentelemetry/semconv.py
+++ b/src/etos_lib/opentelemetry/semconv.py
@@ -28,6 +28,7 @@ class Attributes:
     TESTRUNNER_EXCEPTION = "etos.testrunner.exception"
 
     # Environment generic conventions
+    ENVIRONMENT = "etos.environment"  # environment description as JSON
     ENVIRONMENT_ID = "etos.environment.id"
     ENVIRONMENT_EXCEPTION = "etos.environment.exception"
     ENVIRONMENT_REQUEST = "etos.environment.request"


### PR DESCRIPTION
### Applicable Issues

- https://github.com/eiffel-community/etos/issues/228

### Description of the Change

This change adds OpenTelemetry attribute names as a definition of ETOS-specific semantic conventions. 

### Alternate Designs


### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andreimu@axis.com