### PR TITLE
OpenTelemetry trace id for logstash in hex format

### DIFF
--- a/src/etos_lib/logging/filter.py
+++ b/src/etos_lib/logging/filter.py
@@ -29,8 +29,7 @@ def get_current_otel_trace_id() -> str:
     """
     current_span = trace.get_current_span()
     trace_id = current_span.get_span_context().trace_id
-    trace_id = hex(trace_id).replace("0x", "")
-    return trace_id
+    return trace.format_trace_id(trace_id)
 
 
 class EtosFilter(logging.Filter):  # pylint:disable=too-few-public-methods

--- a/src/etos_lib/logging/filter.py
+++ b/src/etos_lib/logging/filter.py
@@ -28,7 +28,9 @@ def get_current_otel_trace_id() -> str:
     If OpenTelemetry is not enabled, this function will return "0".
     """
     current_span = trace.get_current_span()
-    return str(current_span.get_span_context().trace_id)
+    trace_id = current_span.get_span_context().trace_id
+    trace_id = hex(trace_id).replace("0x", "")
+    return trace_id
 
 
 class EtosFilter(logging.Filter):  # pylint:disable=too-few-public-methods

--- a/src/etos_lib/logging/filter.py
+++ b/src/etos_lib/logging/filter.py
@@ -25,7 +25,7 @@ def get_current_otel_trace_id() -> str:
     The OpenTelemetry trace id is a big integer by default, which is out of range
     of the type 'long' in Elastic. For this reason the trace id is returned as string.
 
-    If OpenTelemetry is not enabled, this function will return "0".
+    If OpenTelemetry is not enabled, this function will return "00000000000000000000000000000000".
     """
     current_span = trace.get_current_span()
     trace_id = current_span.get_span_context().trace_id


### PR DESCRIPTION
### Applicable Issues

- https://github.com/eiffel-community/etos/issues/236

### Description of the Change

Currently OpenTelemetry trace id is returned as an integer converted to string. It needs to be a hex string instead.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com