### PR TITLE
Disable eiffel.publisher.* for RabbitMQLogPublisher

### DIFF
--- a/src/etos_lib/logging/logger.py
+++ b/src/etos_lib/logging/logger.py
@@ -130,10 +130,11 @@ def setup_rabbitmq_logging(log_filter):
 
     root_logger = logging.getLogger()
 
-    # These have to be removed as they create a loop.
-    # They will still work with the other handlers.
+    # These loggers need to be prevented from propagating their logs
+    # to RabbitMQLogPublisher. If they aren't, this may cause a deadlock.
     logging.getLogger("pika").propagate = False
     logging.getLogger("eiffellib.publishers.rabbitmq_publisher").propagate = False
+    logging.getLogger("etos_lib.eiffel.publisher").propagate = False
     logging.getLogger("base_rabbitmq").propagate = False
 
     rabbitmq = RabbitMQLogPublisher(**Config().etos_rabbitmq_publisher_data(), routing_key=None)


### PR DESCRIPTION
### Applicable Issues

- https://github.com/eiffel-community/etos/issues/247

### Description of the Change

This change prevents log propagation from eiffel.publisher.TracingRabbitMQPublisher in RabbitMQLogPublisher to avoid the deadlock condition described in the issue above.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com