### PR TITLE
Fix setuptools_scm version retrieval from detached HEAD

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,14 +11,13 @@ def version_scheme(version) -> str:
 
     Used by setuptools_scm.
     """
-    if version.branch == RELEASE_BRANCH:
-        if version.distance == 0:
-            # If the current commit is on the release branch and has a GIT tag,
-            # use the tag as version:
-            return f"{version.tag}"
-        else:
-            # For untagged commits always add a distance like ".post3"
-            return f"{version.tag}.post{version.distance}"
+    if version.tag and version.distance == 0:
+        # If the current commit has a tag, use the tag as version, regardless of branch.
+        # Note: Github CI creates releases from detached HEAD, not from a particular branch.
+        return f"{version.tag}"
+    elif version.branch == RELEASE_BRANCH and version.tag and version.distance > 0:
+        # For untagged commits on the release branch always add a distance like ".post3"
+        return f"{version.tag}.post{version.distance}"
     else:
         # For non-release branches, make the version as dev and distance:
         return f"{version.tag}.dev{version.distance}"
@@ -29,16 +28,14 @@ def local_scheme(version) -> str:
 
     Used by setuptools_scm.
     """
-    # If current version is dirty, always add dirty tag, regardless of branch.
+    # If current version is dirty, always add dirty suffix, regardless of branch.
     dirty_tag = get_local_dirty_tag(version) if version.dirty else ""
     if dirty_tag:
         return f"{dirty_tag}.{version.node}"
 
-    if version.branch == RELEASE_BRANCH:
-        if version.distance == 0:
-            # no local component for versions on the main release branch:
-            # will create simple versions like 4.1.0
-            return ""
+    if version.distance == 0:
+        # If the current commit has a tag, do not add a local component, regardless of branch.
+        return ""
     # For all other cases, always add the git reference (like "g7839952")
     return f"+{version.node}"
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def version_scheme(version) -> str:
         # For untagged commits on the release branch always add a distance like ".post3"
         return f"{version.tag}.post{version.distance}"
     else:
-        # For non-release branches, make the version as dev and distance:
+        # For non-release branches, mark the version as dev and distance:
         return f"{version.tag}.dev{version.distance}"
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,6 @@
 from setuptools import setup
 from setuptools_scm.version import get_local_dirty_tag
 
-RELEASE_BRANCH = "main"
-
 
 def version_scheme(version) -> str:
     """Get version component for the current commit.
@@ -15,7 +13,7 @@ def version_scheme(version) -> str:
         # If the current commit has a tag, use the tag as version, regardless of branch.
         # Note: Github CI creates releases from detached HEAD, not from a particular branch.
         return f"{version.tag}"
-    elif version.branch == RELEASE_BRANCH and version.tag and version.distance > 0:
+    elif version.branch == "main" and version.tag and version.distance > 0:
         # For untagged commits on the release branch always add a distance like ".post3"
         return f"{version.tag}.post{version.distance}"
     else:


### PR DESCRIPTION
### Applicable Issues

- https://github.com/eiffel-community/etos/issues/248

### Description of the Change

This version fixes the retrieval of version from Git when the commit is not on the release branch. The Git branch is now used only to determine if the tag shall have a "dev" or "post" suffix when the commit is untagged.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@com.axis