### PR TITLE
Add missing sections to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,15 @@ dependencies = [
     "setuptools_scm~=8.0"
 ]
 
+[options]
+zip_safe = false
+include_package_data = true
+python_requires = ">=3.9"
+
+[options.packages.find]
+where = "src"
+exclude = ["tests"]
+
 [project.urls]
 Documentation = "https://etos.readthedocs.io/"
 Homepage = "https://github.com/eiffel-community/etos-library"


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/208

### Description of the Change
This change adds several fields to pyprojects.toml that were missing since the migration from `setup.cfg` to `pyproject.toml`.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com