### PR TITLE
Load client lazily

### DIFF
--- a/src/etos_lib/kubernetes/etos.py
+++ b/src/etos_lib/kubernetes/etos.py
@@ -76,6 +76,7 @@ class Resource:
 class Kubernetes:
     """Kubernetes is a client for fetching ETOS custom resources from Kubernetes."""
 
+    __client = None
     __providers = None
     __requests = None
     __testruns = None
@@ -87,7 +88,13 @@ class Kubernetes:
         """Initialize a dynamic client with version."""
         self.load_kubernetes_config(config_path)
         self.version = f"etos.eiffel-community.github.io/{version}"
-        self.__client = DynamicClient(api_client.ApiClient())
+
+    @property
+    def _client(self) -> DynamicClient:
+        """Client to use when communicating with Kubernetes."""
+        if self.__client is None:
+            self.__client = DynamicClient(api_client.ApiClient())
+        return self.__client
 
     def load_kubernetes_config(self, path: Union[None, str, Path]):
         """Load a Kubernetes config if possible, will log an error if not possible.
@@ -129,7 +136,7 @@ class Kubernetes:
     def providers(self) -> DynamicResource:
         """Providers request returns a client for Provider resources."""
         if self.__providers is None:
-            self.__providers = self.__client.resources.get(
+            self.__providers = self._client.resources.get(
                 api_version=self.version, kind="Provider"
             )
         return self.__providers
@@ -138,7 +145,7 @@ class Kubernetes:
     def environment_requests(self) -> DynamicResource:
         """Environment requests returns a client for EnvironmentRequest resources."""
         if self.__requests is None:
-            self.__requests = self.__client.resources.get(
+            self.__requests = self._client.resources.get(
                 api_version=self.version, kind="EnvironmentRequest"
             )
         return self.__requests
@@ -147,7 +154,7 @@ class Kubernetes:
     def environments(self) -> DynamicResource:
         """Environments returns a client for Environment resources."""
         if self.__environments is None:
-            self.__environments = self.__client.resources.get(
+            self.__environments = self._client.resources.get(
                 api_version=self.version, kind="Environment"
             )
         return self.__environments
@@ -156,5 +163,5 @@ class Kubernetes:
     def testruns(self) -> DynamicResource:
         """Testruns returns a client for TestRun resources."""
         if self.__testruns is None:
-            self.__testruns = self.__client.resources.get(api_version=self.version, kind="TestRun")
+            self.__testruns = self._client.resources.get(api_version=self.version, kind="TestRun")
         return self.__testruns

--- a/src/etos_lib/kubernetes/etos.py
+++ b/src/etos_lib/kubernetes/etos.py
@@ -136,9 +136,7 @@ class Kubernetes:
     def providers(self) -> DynamicResource:
         """Providers request returns a client for Provider resources."""
         if self.__providers is None:
-            self.__providers = self._client.resources.get(
-                api_version=self.version, kind="Provider"
-            )
+            self.__providers = self._client.resources.get(api_version=self.version, kind="Provider")
         return self.__providers
 
     @property


### PR DESCRIPTION
<!--
Filling out the template is required.
Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
Any pull request must pass all automated tests and, if applicable, code style checks.
In addition the pull request must contain tests that cover any new code.
-->

### Applicable Issues
<!--
Reference any relevant issues here. Every pull request should refer to at least one
issue. For exemptions to this rule, see the [contribution guidelines](./CONTRIBUTING.md).
If an issue can be closed when the PR is merged, please use the
[standard notation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
to link the PR to the issue and make sure the latter is closed automatically when the PR
is merged.
-->
eiffel-community/etos-suite-runner#67

### Description of the Change
<!--
Describe the change proposed and its benefits. The maintainers must be able to
understand the design of your change from this description. If we can't get a good idea
of what the code will be doing from this description, the pull request may be closed at
the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not
be familiar with or have worked with the sources addressed by this PR recently, so
please walk us through the concepts. Provide special attention to breaking changes.
-->
If initializing the Kubernetes client outside of Kubernetes then it would crash due to not being able to communicate with expected endpoints. We should be allowed to initialize the client in tests.

### Alternate Designs
<!--
Explain what other alternates were considered and why the proposed version was selected.
-->

### Possible Drawbacks
<!-- Describe the possible side-effects or negative impacts of this change. -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
