### PR TITLE
Environment(Request): make identifier optional

### DIFF
--- a/src/etos_lib/kubernetes/schemas/environment.py
+++ b/src/etos_lib/kubernetes/schemas/environment.py
@@ -24,9 +24,9 @@ class EnvironmentSpec(BaseModel):
     """EnvironmentSpec is the specification of a Environment Kubernetes resource."""
 
     name: str
-    suite_id: str
-    sub_suite_id: str
-    test_suite_started_id: str
+    suite_id: Optional[str]
+    sub_suite_id: Optional[str]
+    test_suite_started_id: Optional[str]
     artifact: str
     context: str
     priority: int = 1

--- a/src/etos_lib/kubernetes/schemas/environment_request.py
+++ b/src/etos_lib/kubernetes/schemas/environment_request.py
@@ -58,7 +58,7 @@ class EnvironmentRequestSpec(BaseModel):
 
     id: str
     name: Optional[str] = None
-    identifier: str
+    identifier: Optional[str] = None
     image: str
     imagePullPolicy: str
     artifact: str


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/266

### Description of the Change
This change introduces handling of environment requests and environments that aren't bound to suite id/testrun and thus have no `identifier` attribute. This allows creating `EnvironmentRequest` / `Environment` objects without a testrun using Kubernetes API directly.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com