### PR TITLE
Remove environment record form the ETOS logging filter

### DIFF
--- a/src/etos_lib/logging/filter.py
+++ b/src/etos_lib/logging/filter.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 """ETOS filter."""
 import logging
+import threading
 
 from opentelemetry import trace
 
@@ -35,25 +36,22 @@ def get_current_otel_trace_id() -> str:
 class EtosFilter(logging.Filter):  # pylint:disable=too-few-public-methods
     """Filter for adding extra application specific data to log messages."""
 
-    def __init__(self, application, version, environment, local):
+    def __init__(self, application: str, version: str, local: threading.local) -> None:
         """Initialize with a few ETOS application fields.
 
         :param application: Name of application.
         :type application: str
         :param version: Version of application.
         :type version: str
-        :param environment: In which environment is this executing.
-        :type environment: str
         :param local: Thread-local configuration information.
         :type local: :obj:`threading.local`
         """
         self.application = application
         self.version = version
-        self.environment = environment
         self.local = local
         super().__init__()
 
-    def filter(self, record):
+    def filter(self, record: logging.LogRecord) -> bool:
         """Add contextual data to log record.
 
         :param record: Log record to add data to.
@@ -63,7 +61,6 @@ class EtosFilter(logging.Filter):  # pylint:disable=too-few-public-methods
         """
         record.application = self.application
         record.version = self.version
-        record.environment = self.environment
         record.opentelemetry_trace_id = get_current_otel_trace_id()
 
         # Add each thread-local attribute to record.

--- a/src/etos_lib/logging/logger.py
+++ b/src/etos_lib/logging/logger.py
@@ -189,7 +189,7 @@ def setup_otel_logging(
 def setup_logging(
     application: str,
     version: str,
-    environment: str,  # This is kept to maintain API compatibility
+    environment: str,  # pylint: disable=unused-argument # This is kept to maintain backward compatibility
     otel_resource: Resource = None,
     config_file: Path = DEFAULT_CONFIG,
 ) -> None:

--- a/src/etos_lib/logging/logger.py
+++ b/src/etos_lib/logging/logger.py
@@ -189,7 +189,7 @@ def setup_otel_logging(
 def setup_logging(
     application: str,
     version: str,
-    environment: str,  # pylint: disable=unused-argument # This is kept to maintain backward compatibility
+    environment: str = None,  # pylint: disable=unused-argument # This is kept to maintain backward compatibility
     otel_resource: Resource = None,
     config_file: Path = DEFAULT_CONFIG,
 ) -> None:

--- a/src/etos_lib/logging/logger.py
+++ b/src/etos_lib/logging/logger.py
@@ -189,7 +189,7 @@ def setup_otel_logging(
 def setup_logging(
     application: str,
     version: str,
-    environment: str,
+    environment: str,  # This is kept to maintain API compatibility
     otel_resource: Resource = None,
     config_file: Path = DEFAULT_CONFIG,
 ) -> None:
@@ -208,7 +208,7 @@ def setup_logging(
         config = load(yaml_file, Loader=SafeLoader)
     logging_config = config["logging"]
 
-    log_filter = EtosFilter(application, version, environment, FORMAT_CONFIG)
+    log_filter = EtosFilter(application, version, FORMAT_CONFIG)
 
     # Create a default logger which will not propagate messages
     # to the root logger. This logger will create records for all


### PR DESCRIPTION
### Description of the Change
All the ETOS service currently implement a kind of broken logic to determine what environment (Development, (staging) and Production) that the specific service is running in. This logic does not take into account the possibility of one or several staging environments, this then bleeds into the logging setup and can interfere with telemetry logging signals, and thus by removing the expicit enviromnent requirement in EtosFilter we mitigate potential telemetry interference. We retain the parameter to the setup_logging function as a way to keep etos-library backwards compatible.

### Alternate Designs
We could create a specific filter to use with specific telemetry logging signals but the generic logic to know which to use when might get tricky in the long run.

### Possible Drawbacks
Logs no longer have the envronment record available on them.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by:  Fredrik Fristedt <<fredrik.fristedt@axis.com>>
