### PR TITLE
log_processors.ToStringProcessor: rename emit() -> on_emit()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,3 +57,6 @@ testpaths = ["tests"]
 
 [tool.setuptools.packages]
 find = { where = ["src"], exclude = ["tests"] }
+
+[tool.setuptools_scm]
+root = "."

--- a/src/etos_lib/logging/log_processors.py
+++ b/src/etos_lib/logging/log_processors.py
@@ -21,7 +21,7 @@ from opentelemetry.sdk._logs import LogData, LogRecordProcessor
 class ToStringProcessor(LogRecordProcessor):
     """Simple log record processor to convert all log records to type string."""
 
-    def emit(self, log_data: LogData) -> None:
+    def on_emit(self, log_data: LogData) -> None:
         """Change record body to string and emit the `LogData`."""
         record = log_data.log_record
         if not isinstance(record.body, (str, bool, int, float)):


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/421

### Description of the Change
This change updates the `ToStringProcessor` class to make it compatible with the latest OpenTelemetry Python SDK where the method name has been changed:

Latest version: 1.36.0: on_emit()
https://github.com/open-telemetry/opentelemetry-python/blob/1aaa2a25872c36aee208442ff654a67f5daa5736/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py#L360
 
Older versions, e. g. 1.31.1: emit()
https://github.com/open-telemetry/opentelemetry-python/blob/74509a111acd486d195ec5ea8478c8ccbf1f93c1/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py#L270

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com