### PR TITLE
fix deprecation warning for utcfromtimestamp()

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.13
       - name: Install Tox
         run: pip install tox
       - name: Upgrade setuptools

--- a/src/etos_lib/logging/formatter.py
+++ b/src/etos_lib/logging/formatter.py
@@ -98,4 +98,9 @@ class EtosLogFormatter(logging.Formatter):
         # Make Logstash's @timestamp parser happy by including a "T"
         # between the date and the time. Append 'Z' to make it clear
         # that the timestamp is UTC.
-        return datetime.datetime.utcfromtimestamp(record.created).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+        try:
+            # Use the timezone-aware method (Python 3.11+) to avoid deprecation warnings
+            return datetime.datetime.fromtimestamp(record.created, datetime.UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+        except AttributeError:
+            # Fallback to deprecated method for older Python versions
+            return datetime.datetime.utcfromtimestamp(record.created).strftime("%Y-%m-%dT%H:%M:%S.%fZ")


### PR DESCRIPTION
### Applicable Issues
- 

### Description of the Change
This change fixes the deprecation warning for `utcfromtimestamp()` seen in newer Python versions.

### Alternate Designs


### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com