### PR TITLE
Implement a logger that sends logs via RabbitMQ streams

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,13 @@ jobs:
   run-tox:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    services:
+      rabbitmq-streaming:
+        image: rabbitmq:4.1
+        env:
+          RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS: "-rabbitmq_stream advertised_host localhost"
+        ports:
+          - 5552:5552
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -21,6 +28,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.13
+      - name: Enable RabbitMQ Plugins
+        run: docker exec ${{ job.services.rabbitmq-streaming.id }} rabbitmq-plugins enable rabbitmq_stream
       - name: Install Tox
         run: pip install tox
       - name: Upgrade setuptools

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Running tests
 
 To run the tests, you will need to have a running instance of RabbitMQ. You can use Docker to run RabbitMQ locally:
 
-   docker run -it --rm --name rabbitmq -p 5552:5552 -p 5672:5672 -e RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS='-rabbitmq_stream advertised_host localhost' rabbitmq:4.1
+   docker run -d --rm --name rabbitmq -p 5552:5552 -p 5672:5672 -e RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS='-rabbitmq_stream advertised_host localhost' rabbitmq:4.1
 
 And enable the stream plugin with:
 

--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,21 @@ Contribute
 - Source Code: https://github.com/eiffel-community/etos-library
 
 
+Running tests
+=============
+
+To run the tests, you will need to have a running instance of RabbitMQ. You can use Docker to run RabbitMQ locally:
+
+   docker run -it --rm --name rabbitmq -p 5552:5552 -p 5672:5672 -e RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS='-rabbitmq_stream advertised_host localhost' rabbitmq:4.1
+
+And enable the stream plugin with:
+
+   docker exec rabbitmq rabbitmq-plugins enable rabbitmq_stream
+
+Then you can run the tests with:
+
+   pytest
+
 Support
 =======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ requires-python = ">=3.10"
 dependencies = [
     "gql[requests]~=3.4",
     "eiffellib[rabbitmq]~=2.4",
+    "rstream~=1.0",
     "requests~=2.31",
     "kubernetes~=26.1",
     "pydantic~=2.1",
@@ -38,6 +39,9 @@ Repository = "https://github.com/eiffel-community/etos-library"
 
 [project.optional-dependencies]
 testing = ["pytest", "pytest-cov"]
+
+[tool.black]
+line-length = 100
 
 [tool.build_sphinx]
 source_dir = "docs"

--- a/src/etos_lib/etos.py
+++ b/src/etos_lib/etos.py
@@ -30,6 +30,7 @@ from .lib.feature_flags import FeatureFlags
 from .lib.http import Http
 from .lib.monitor import Monitor
 from .lib.utils import Utils
+from .messaging.publisher import Publisher
 
 
 class ETOS:  # pylint: disable=too-many-instance-attributes
@@ -58,6 +59,21 @@ class ETOS:  # pylint: disable=too-many-instance-attributes
         """Delete references to eiffel publisher and subscriber."""
         self.config.set("publisher", None)
         self.config.set("subscriber", None)
+        self.config.set("messagebus", None)
+
+    def messagebus_publisher(self) -> Publisher:
+        """Start the internal messagebus publisher using config data from ETOS library."""
+        messagebus = self.config.get("messagebus")
+        if messagebus is None:
+            config = self.config.etos_rabbitmq_stream_publisher_data()
+            if config.get("stream_name") is None:
+                raise PublisherConfigurationMissing
+            messagebus = Publisher(**config)
+            if not self.debug.disable_sending_events:
+                messagebus.start()
+                messagebus.wait_start()
+            self.config.set("messagebus", messagebus)
+        return messagebus
 
     def start_publisher(self):
         """Start the RabbitMQ publisher using config data from ETOS library config service."""

--- a/src/etos_lib/lib/config.py
+++ b/src/etos_lib/lib/config.py
@@ -16,8 +16,8 @@
 """ETOS Library config."""
 
 import json
-from pprint import pprint
 import os
+from pprint import pprint
 
 
 class Config:
@@ -89,6 +89,19 @@ class Config:
             "username": os.getenv("ETOS_RABBITMQ_USERNAME", None),
             "password": os.getenv("ETOS_RABBITMQ_PASSWORD", None),
             "port": int(os.getenv("ETOS_RABBITMQ_PORT", "5672")),
+            "vhost": os.getenv("ETOS_RABBITMQ_VHOST", None),
+            "ssl": ssl,
+        }
+
+    def etos_rabbitmq_stream_publisher_data(self):
+        """Get RabbitMQ parameters for the ETOS rabbitmq stream service."""
+        ssl = os.getenv("ETOS_RABBITMQ_SSL", "true") == "true"
+        return {
+            "host": os.getenv("ETOS_RABBITMQ_HOST", "127.0.0.1"),
+            "username": os.getenv("ETOS_RABBITMQ_USERNAME", None),
+            "password": os.getenv("ETOS_RABBITMQ_PASSWORD", None),
+            "port": int(os.getenv("ETOS_RABBITMQ_STREAM_PORT", "5552")),
+            "stream_name": os.getenv("ETOS_RABBITMQ_STREAM_NAME", None),
             "vhost": os.getenv("ETOS_RABBITMQ_VHOST", None),
             "ssl": ssl,
         }

--- a/src/etos_lib/logging/logger.py
+++ b/src/etos_lib/logging/logger.py
@@ -50,6 +50,7 @@ from etos_lib.logging.formatter import EtosLogFormatter
 from etos_lib.logging.log_processors import ToStringProcessor
 from etos_lib.logging.log_publisher import RabbitMQLogPublisher
 from etos_lib.logging.rabbitmq_handler import RabbitMQHandler
+from etos_lib.messaging.publisher import Publisher
 
 DEFAULT_CONFIG = Path(__file__).parent.joinpath("default_config.yaml")
 DEFAULT_LOG_PATH = Debug().default_log_path
@@ -150,12 +151,24 @@ def setup_rabbitmq_logging(log_filter: EtosFilter) -> None:
     logging.getLogger("etos_lib.eiffel.publisher").propagate = False
     logging.getLogger("base_rabbitmq").propagate = False
 
+    # Backwards compatibility
     rabbitmq = RabbitMQLogPublisher(**Config().etos_rabbitmq_publisher_data(), routing_key=None)
     if Debug().enable_sending_logs:
         rabbitmq.start()
         atexit.register(close_rabbit, rabbitmq)
 
-    rabbit_handler = RabbitMQHandler(rabbitmq)
+    config = Config().etos_rabbitmq_stream_publisher_data()
+    if config.get("stream_name") is not None:
+        messagebus = Config().get("messagebus")
+        if messagebus is None:
+            messagebus = Publisher(**config)
+            Config().set("messagebus", messagebus)
+    messagebus = Config().get("messagebus")
+    if messagebus is not None and Debug().enable_sending_logs:
+        messagebus.start()
+        messagebus.wait_start()
+
+    rabbit_handler = RabbitMQHandler(messagebus, rabbitmq)
     rabbit_handler.setFormatter(EtosLogFormatter())
     rabbit_handler.setLevel(loglevel)
     rabbit_handler.addFilter(log_filter)

--- a/src/etos_lib/logging/logger.py
+++ b/src/etos_lib/logging/logger.py
@@ -165,7 +165,9 @@ def setup_rabbitmq_logging(log_filter: EtosFilter) -> None:
             Config().set("messagebus", messagebus)
     messagebus = Config().get("messagebus")
     if messagebus is not None and Debug().enable_sending_logs:
-        messagebus.start()
+        # Checks if the thread is alive, not the publisher itself.
+        if not messagebus.is_alive():
+            messagebus.start()
         messagebus.wait_start()
 
     rabbit_handler = RabbitMQHandler(messagebus, rabbitmq)

--- a/src/etos_lib/logging/rabbitmq_handler.py
+++ b/src/etos_lib/logging/rabbitmq_handler.py
@@ -82,7 +82,7 @@ class RabbitMQHandler(logging.StreamHandler):
             routing_key = f"{identifier}.log.{record.levelname}"
             self.rabbitmq.send_event(msg, routing_key=routing_key)
 
-        if self.stream is not None and send and self.stream.is_alive():
+        if self.stream is not None and send and self.stream.is_publisher_alive():
             if identifier == "Unknown":
                 raise ValueError("Trying to send a user log when identifier is not set")
             if not isinstance(msg, dict):

--- a/src/etos_lib/logging/rabbitmq_handler.py
+++ b/src/etos_lib/logging/rabbitmq_handler.py
@@ -17,7 +17,6 @@
 
 import json
 import logging
-from typing import Optional
 
 from etos_lib.messaging.events import Message
 from etos_lib.messaging.publisher import Publisher
@@ -45,8 +44,8 @@ class RabbitMQHandler(logging.StreamHandler):
 
     def __init__(
         self,
-        stream: Optional[Publisher] = None,
-        rabbitmq: Optional[RabbitMQLogPublisher] = None,
+        stream: Publisher | None = None,
+        rabbitmq: RabbitMQLogPublisher | None = None,
     ):
         """Initialize."""
         super().__init__()

--- a/src/etos_lib/logging/rabbitmq_handler.py
+++ b/src/etos_lib/logging/rabbitmq_handler.py
@@ -17,6 +17,13 @@
 
 import json
 import logging
+from typing import Optional
+
+from etos_lib.messaging.events import Message
+from etos_lib.messaging.publisher import Publisher
+from etos_lib.messaging.types import Log
+
+from .log_publisher import RabbitMQLogPublisher
 
 
 class RabbitMQHandler(logging.StreamHandler):
@@ -36,9 +43,14 @@ class RabbitMQHandler(logging.StreamHandler):
 
     closing = False
 
-    def __init__(self, rabbitmq):
+    def __init__(
+        self,
+        stream: Optional[Publisher] = None,
+        rabbitmq: Optional[RabbitMQLogPublisher] = None,
+    ):
         """Initialize."""
         super().__init__()
+        self.stream = stream
         self.rabbitmq = rabbitmq
 
     def emit(self, record):
@@ -60,10 +72,20 @@ class RabbitMQHandler(logging.StreamHandler):
             identifier = record.identifier
         except AttributeError:
             identifier = json.loads(msg).get("identifier", "Unknown")
+
+        # Backwards compatibility
         # An unknown identifier will never be picked up by user log handler
         # so it is unnecessary to send it.
-        routing_key = f"{identifier}.log.{record.levelname}"
-        if send and self.rabbitmq.is_alive():
+        if self.rabbitmq is not None and send and self.rabbitmq.is_alive():
             if identifier == "Unknown":
                 raise ValueError("Trying to send a user log when identifier is not set")
+
+            routing_key = f"{identifier}.log.{record.levelname}"
             self.rabbitmq.send_event(msg, routing_key=routing_key)
+
+        if self.stream is not None and send and self.stream.is_alive():
+            if identifier == "Unknown":
+                raise ValueError("Trying to send a user log when identifier is not set")
+            if not isinstance(msg, dict):
+                msg = json.loads(msg)
+            self.stream.publish(identifier, Message(data=Log(**msg)))

--- a/src/etos_lib/messaging/__init__.py
+++ b/src/etos_lib/messaging/__init__.py
@@ -1,0 +1,16 @@
+# Copyright Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""ETOS Library messaging module."""

--- a/src/etos_lib/messaging/events.py
+++ b/src/etos_lib/messaging/events.py
@@ -36,7 +36,7 @@ class Event(BaseModel):
         """Return the string representation of an event."""
         return f"{self.event}({self.id}): {self.data}"
 
-    def __eq__(self, other: "Event") -> bool:  # type:ignore
+    def __eq__(self, other: "Event") -> bool:  # type: ignore
         """Check if the event is the same by testing the IDs."""
         if self.id is None or other.id is None:
             return super().__eq__(other)

--- a/src/etos_lib/messaging/events.py
+++ b/src/etos_lib/messaging/events.py
@@ -1,0 +1,128 @@
+# Copyright Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""ETOS internal messaging events."""
+
+import inspect
+import sys
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
+
+from .types import File, Log, Result
+
+
+class Event(BaseModel):
+    """Base internal messaging event."""
+
+    id: Optional[int] = None
+    event: str = "Unknown"
+    data: Any
+    meta: str = "*"
+
+    def __str__(self) -> str:
+        """Return the string representation of an event."""
+        return f"{self.event}({self.id}): {self.data}"
+
+    def __eq__(self, other: "Event") -> bool:  # type:ignore
+        """Check if the event is the same by testing the IDs."""
+        if self.id is None or other.id is None:
+            return super().__eq__(other)
+        return self.id == other.id
+
+
+class ServerEvent(Event):
+    """Events to be handled by the client."""
+
+
+class UserEvent(Event):
+    """Events to be handled by the user."""
+
+
+class Ping(ServerEvent):
+    """A ping event. Sent to keep connection between server and client alive."""
+
+    event: str = "Ping"
+    data: Any = None
+
+
+class Error(ServerEvent):
+    """An error from the messaging server."""
+
+    event: str = "Error"
+    data: Any = None
+
+
+class Unknown(UserEvent):
+    """An unknown event."""
+
+    event: str = "Unknown"
+    data: Any = None
+
+
+class Shutdown(UserEvent):
+    """A shutdown event from ETOS."""
+
+    event: str = "Shutdown"
+    data: Result
+
+    def __str__(self) -> str:
+        """Return the string representation of a shutdown."""
+        return (
+            f"Result(conclusion={self.data.conclusion}, "
+            f"verdict={self.data.verdict}, description={self.data.description})"
+        )
+
+
+class Message(UserEvent):
+    """An ETOS user log event."""
+
+    event: str = "Message"
+    data: Log
+    meta: str = Field(default_factory=lambda data: data["data"].level)
+
+    def __str__(self) -> str:
+        """Return the string representation of a user log."""
+        return self.data.message
+
+
+class Report(UserEvent):
+    """An ETOS test case report file event."""
+
+    event: str = "Report"
+    data: File
+
+    def __str__(self) -> str:
+        """Return the string representation of a file."""
+        return f"[{self.data.name}]({self.data.url})"
+
+
+class Artifact(UserEvent):
+    """An ETOS test case artifact file event."""
+
+    event: str = "Artifact"
+    data: File
+
+    def __str__(self) -> str:
+        """Return the string representation of a file."""
+        return f"[{self.data.name}]({self.data.url})"
+
+
+def parse(event: dict) -> Event:
+    """Parse an event dict and return a corresponding Event class."""
+    for name, obj in inspect.getmembers(sys.modules[__name__]):
+        if event.get("event", "").lower() == name.lower():
+            return obj.model_validate(event)
+    return Unknown(**event)

--- a/src/etos_lib/messaging/events.py
+++ b/src/etos_lib/messaging/events.py
@@ -17,7 +17,7 @@
 
 import inspect
 import sys
-from typing import Any, Optional
+from typing import Any
 
 from pydantic import BaseModel, Field
 
@@ -27,7 +27,7 @@ from .types import File, Log, Result
 class Event(BaseModel):
     """Base internal messaging event."""
 
-    id: Optional[int] = None
+    id: int | None = None
     event: str = "Unknown"
     data: Any
     meta: str = "*"

--- a/src/etos_lib/messaging/publisher.py
+++ b/src/etos_lib/messaging/publisher.py
@@ -34,10 +34,6 @@ class Publisher(threading.Thread):
 
     logger = logging.getLogger(__name__)
 
-    __shutdown = threading.Event()
-    __closed = threading.Event()
-    __started = threading.Event()
-    __queue: asyncio.Queue = asyncio.Queue()
     __confirmed: int = 0
     __unconfirmed: int = 0
     __parent_thread: threading.Thread
@@ -54,6 +50,10 @@ class Publisher(threading.Thread):
     ):
         """Set up parameters for a rabbitmq stream connection."""
         super().__init__()
+        self.__shutdown = threading.Event()
+        self.__closed = threading.Event()
+        self.__started = threading.Event()
+        self.__queue = asyncio.Queue()
         self.__parameters = {
             "host": host,
             "port": port,

--- a/src/etos_lib/messaging/publisher.py
+++ b/src/etos_lib/messaging/publisher.py
@@ -27,6 +27,7 @@ from .events import Event
 
 # pylint: disable=too-many-arguments
 # pylint: disable=too-many-positional-arguments
+# pylint: disable=too-many-instance-attributes
 
 
 class Publisher(threading.Thread):

--- a/src/etos_lib/messaging/publisher.py
+++ b/src/etos_lib/messaging/publisher.py
@@ -38,6 +38,7 @@ class Publisher(threading.Thread):
     __confirmed: int = 0
     __unconfirmed: int = 0
     __parent_thread: threading.Thread
+    __loop: None | asyncio.AbstractEventLoop = None
 
     def __init__(
         self,
@@ -95,7 +96,9 @@ class Publisher(threading.Thread):
 
     def is_alive(self) -> bool:
         """Check if the publisher is alive, meaning it has not shutdown or closed."""
-        return not self.__closed.is_set() and not self.__shutdown.is_set()
+        return (
+            self.__started.is_set() and not self.__closed.is_set() and not self.__shutdown.is_set()
+        )
 
     def wait_start(self, timeout: float = 60.0):
         """Wait for the publisher to start, meaning it has started consuming messages."""
@@ -113,6 +116,7 @@ class Publisher(threading.Thread):
         while True:
             await asyncio.sleep(0.1)
             if not self.__started.is_set():
+                self.__loop = asyncio.get_running_loop()
                 self.logger.debug("Publisher started")
                 self.__started.set()
             # Main thread died, shut down.
@@ -179,6 +183,8 @@ class Publisher(threading.Thread):
         """Send an event to the publisher, which will be published to RabbitMQ."""
         if not self.is_alive():
             raise RuntimeError("Publisher is not alive")
+        if self.__loop is None:
+            raise RuntimeError("Publisher loop is not running")
         amqp_message = AMQPMessage(
             body=bytes(event.model_dump_json(), encoding="utf-8"),
             application_properties={
@@ -187,6 +193,8 @@ class Publisher(threading.Thread):
                 "meta": event.meta,
             },
         )
-        self.__queue.put_nowait(amqp_message)
+        # Since we are running the publisher in a separate thread, we need to use
+        # run_coroutine_threadsafe to put the message in the queue.
+        asyncio.run_coroutine_threadsafe(self.__queue.put(amqp_message), self.__loop)
         with self.__lock:
             self.__unconfirmed += 1

--- a/src/etos_lib/messaging/publisher.py
+++ b/src/etos_lib/messaging/publisher.py
@@ -94,7 +94,7 @@ class Publisher(threading.Thread):
         if wait:
             self.wait_closed(timeout=60)
 
-    def is_alive(self) -> bool:
+    def is_publisher_alive(self) -> bool:
         """Check if the publisher is alive, meaning it has not shutdown or closed."""
         return (
             self.__started.is_set() and not self.__closed.is_set() and not self.__shutdown.is_set()
@@ -181,7 +181,7 @@ class Publisher(threading.Thread):
 
     def publish(self, testrun_id: str, event: Event):
         """Send an event to the publisher, which will be published to RabbitMQ."""
-        if not self.is_alive():
+        if not self.is_publisher_alive():
             raise RuntimeError("Publisher is not alive")
         if self.__loop is None:
             raise RuntimeError("Publisher loop is not running")

--- a/src/etos_lib/messaging/publisher.py
+++ b/src/etos_lib/messaging/publisher.py
@@ -53,6 +53,7 @@ class Publisher(threading.Thread):
         self.__shutdown = threading.Event()
         self.__closed = threading.Event()
         self.__started = threading.Event()
+        self.__lock = threading.Lock()
         self.__queue = asyncio.Queue()
         self.__parameters = {
             "host": host,
@@ -109,7 +110,7 @@ class Publisher(threading.Thread):
         """Consume messages from the queue and publish them until shutdown is requested."""
         self.logger.debug("Consuming forever")
         while True:
-            time.sleep(0.1)
+            await asyncio.sleep(0.1)
             if not self.__started.is_set():
                 self.logger.debug("Publisher started")
                 self.__started.set()
@@ -160,7 +161,8 @@ class Publisher(threading.Thread):
         """Publish confirm callback, increments a counter if the message was confirmed."""
         if confirmation.is_confirmed:
             self.logger.debug("Message confirmed: %r", confirmation)
-            self.__confirmed += 1
+            with self.__lock:
+                self.__confirmed += 1
 
     async def __wait_for_unpublished_events(self, timeout: float):
         """Wait for unpublished events to be confirmed until the timeout is reached."""
@@ -185,4 +187,5 @@ class Publisher(threading.Thread):
             },
         )
         self.__queue.put_nowait(amqp_message)
-        self.__unconfirmed = self.__queue.qsize()
+        with self.__lock:
+            self.__unconfirmed += 1

--- a/src/etos_lib/messaging/publisher.py
+++ b/src/etos_lib/messaging/publisher.py
@@ -1,0 +1,188 @@
+# Copyright Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""ETOS messaging event publisher."""
+
+import asyncio
+import logging
+import ssl as _ssl
+import threading
+import time
+
+from rstream import AMQPMessage, ConfirmationStatus, Producer
+
+from .events import Event
+
+# pylint: disable=too-many-arguments
+# pylint: disable=too-many-positional-arguments
+
+
+class Publisher(threading.Thread):
+    """Publisher that runs in a separate thread and publishes messages to RabbitMQ."""
+
+    logger = logging.getLogger(__name__)
+
+    __shutdown = threading.Event()
+    __closed = threading.Event()
+    __started = threading.Event()
+    __queue: asyncio.Queue = asyncio.Queue()
+    __confirmed: int = 0
+    __unconfirmed: int = 0
+    __parent_thread: threading.Thread
+
+    def __init__(
+        self,
+        host,
+        stream_name,
+        username=None,
+        password=None,
+        port=5552,
+        vhost=None,
+        ssl=True,
+    ):
+        """Set up parameters for a rabbitmq stream connection."""
+        super().__init__()
+        self.__parameters = {
+            "host": host,
+            "port": port,
+            "vhost": vhost,
+            "username": username,
+            "password": password,
+        }
+        if ssl is True:
+            self.__parameters["ssl_context"] = _ssl.create_default_context()
+        self.stream_name = stream_name
+        self.__parent_thread = threading.current_thread()
+
+    def run(self):
+        """Run the publisher, consuming messages from the queue and publishing them."""
+        # Register the close method to be called when the thread is exiting, ensuring that
+        # resources are cleaned up properly.
+        # Since this is not a daemon thread the regular atexit handlers won't be called when the
+        # main thread shuts down, so we need to use the protected _register_atexit method to
+        # ensure that the close method is called when the main thread is exiting.
+
+        # Our reason for not running this as a daemon thread is that if the interpreter exits
+        # (which is what triggers atexit) it will shutdown the threadpoolexecutor used in asyncio,
+        # which will cause the cleanup to crash with a RuntimeError.
+        threading._register_atexit(self.close, wait=True)  # pylint:disable=protected-access
+        try:
+            asyncio.run(self.__wrap_producer())
+        finally:
+            self.__closed.set()
+        self.logger.debug("Publisher thread exiting")
+
+    def close(self, wait: bool = False):
+        """Close the publisher, signaling it to stop consuming messages."""
+        self.logger.debug("Stopping thread")
+        self.__shutdown.set()
+        if wait:
+            self.wait_closed(timeout=60)
+
+    def is_alive(self) -> bool:
+        """Check if the publisher is alive, meaning it has not shutdown or closed."""
+        return not self.__closed.is_set() and not self.__shutdown.is_set()
+
+    def wait_start(self, timeout: float = 60.0):
+        """Wait for the publisher to start, meaning it has started consuming messages."""
+        if not self.__started.wait(timeout=timeout):
+            raise TimeoutError("Timeout while waiting for publisher to start")
+
+    def wait_closed(self, timeout: float = 60.0):
+        """Wait for the publisher to close, meaning it has stopped consuming messages."""
+        if not self.__closed.wait(timeout=timeout):
+            raise TimeoutError("Timeout while waiting for publisher to close")
+
+    async def __consume_forever(self, producer: Producer):
+        """Consume messages from the queue and publish them until shutdown is requested."""
+        self.logger.debug("Consuming forever")
+        while True:
+            time.sleep(0.1)
+            if not self.__started.is_set():
+                self.logger.debug("Publisher started")
+                self.__started.set()
+            # Main thread died, shut down.
+            if not self.__parent_thread.is_alive() and not self.__shutdown.is_set():
+                self.logger.debug("Main thread died, shutting down")
+                self.close()
+            await self.__consume_queue(producer)
+
+            # If shutdown is requested and the queue is empty, wait for unpublished events and
+            # break the loop.
+            if self.__shutdown.is_set() and self.__queue.empty():
+                self.logger.debug(
+                    "Shutdown requested and queue is empty, waiting for unpublished events"
+                )
+                await self.__wait_for_unpublished_events(timeout=30)
+                break
+        self.__closed.set()
+        self.logger.debug("Stopped consuming")
+
+    async def __filter_value_extractor(self, message: AMQPMessage) -> str:
+        """Extract the filter value from the message properties."""
+        properties = message.application_properties
+        if properties.get("meta", "") == "":
+            properties["meta"] = "*"
+        return f"{properties['identifier']}.{properties['type']}.{properties['meta']}"
+
+    async def __wrap_producer(self):
+        """Wrap the producer and consume messages until shutdown is requested."""
+        async with Producer(
+            **self.__parameters,
+            filter_value_extractor=self.__filter_value_extractor,
+        ) as producer:
+            await self.__consume_forever(producer)
+
+    async def __consume_queue(self, producer: Producer):
+        """Consume messages from the queue and publish them until the queue is empty."""
+        while not self.__queue.empty():
+            message = await self.__queue.get()
+            self.logger.debug("Publishing message: %r", message)
+            await producer.send(
+                self.stream_name,
+                message,
+                on_publish_confirm=self.__on_publish_confirm,
+            )
+
+    async def __on_publish_confirm(self, confirmation: ConfirmationStatus):
+        """Publish confirm callback, increments a counter if the message was confirmed."""
+        if confirmation.is_confirmed:
+            self.logger.debug("Message confirmed: %r", confirmation)
+            self.__confirmed += 1
+
+    async def __wait_for_unpublished_events(self, timeout: float):
+        """Wait for unpublished events to be confirmed until the timeout is reached."""
+        self.logger.debug("Waiting for unpublished events, timeout = %ds", timeout)
+        timeout = time.time() + timeout
+        while self.__unconfirmed > self.__confirmed:
+            await asyncio.sleep(0.1)
+            if time.time() > timeout:
+                raise TimeoutError("Timeout while waiting for unpublished events")
+        self.logger.debug("All events published")
+
+    def publish(self, testrun_id: str, event: Event):
+        """Send an event to the publisher, which will be published to RabbitMQ."""
+        if not self.is_alive():
+            raise RuntimeError("Publisher is not alive")
+        amqp_message = AMQPMessage(
+            body=bytes(event.model_dump_json(), encoding="utf-8"),
+            application_properties={
+                "identifier": testrun_id,
+                "type": event.event.lower(),
+                "meta": event.meta,
+            },
+        )
+        self.__queue.put_nowait(amqp_message)
+        self.__unconfirmed = self.__queue.qsize()

--- a/src/etos_lib/messaging/types.py
+++ b/src/etos_lib/messaging/types.py
@@ -16,10 +16,9 @@
 """Types used by events but are not events themselves."""
 
 from datetime import datetime
-from typing import Optional
+from typing import Annotated
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, StringConstraints
-from typing_extensions import Annotated
 
 
 class File(BaseModel):
@@ -27,7 +26,7 @@ class File(BaseModel):
 
     url: str
     name: str
-    directory: Optional[str] = None
+    directory: str | None = None
     checksums: dict = {}
 
 

--- a/src/etos_lib/messaging/types.py
+++ b/src/etos_lib/messaging/types.py
@@ -1,0 +1,60 @@
+# Copyright Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Types used by events but are not events themselves."""
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, StringConstraints
+from typing_extensions import Annotated
+
+
+class File(BaseModel):
+    """An ETOS file event."""
+
+    url: str
+    name: str
+    directory: Optional[str] = None
+    checksums: dict = {}
+
+
+class Log(BaseModel):
+    """An ETOS log."""
+
+    # Log describes all the required fields for a log message, but when running in python we get
+    # a ton of other key/value pairs that give extra context if wanted, setting extra='allow' will
+    # make sure that these extra fields are also published.
+    model_config = ConfigDict(extra="allow")
+
+    message: str
+    level: Annotated[str, StringConstraints(to_lower=True)] = Field("info", alias="levelname")
+    name: str
+    # The datestring field is, by default, generated as '@timestamp' but since
+    # that is illegal in python we convert the name over to 'datestring'. Using
+    # an aliased Field.
+    # The '@timestamp' key is necessary for logstash, which we support, so we
+    # cannot update the formatter that creates the '@timestamp' key.
+    datestring: datetime = Field(
+        serialization_alias="datestring", validation_alias=AliasChoices("@timestamp", "datestring")
+    )
+
+
+class Result(BaseModel):
+    """Shutdown result."""
+
+    conclusion: str
+    verdict: str
+    description: str = ""

--- a/tests/library/__init__.py
+++ b/tests/library/__init__.py
@@ -1,0 +1,16 @@
+# Copyright Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test libraries."""

--- a/tests/library/consumer.py
+++ b/tests/library/consumer.py
@@ -1,0 +1,110 @@
+# Copyright Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Messagebus consumer for ETOS internal messaging for tests to use."""
+
+import asyncio
+import json
+import threading
+
+from rstream import AMQPMessage, Consumer, MessageContext, amqp_decoder
+
+from etos_lib.messaging.events import parse
+
+# pylint: disable=too-many-arguments
+# pylint: disable=too-many-positional-arguments
+
+
+class SimpleConsumer(threading.Thread):
+    """A simple consumer that runs in a separate thread and consumes messages from RabbitMQ."""
+
+    def __init__(
+        self,
+        host,
+        stream_name,
+        username=None,
+        password=None,
+        port=5552,
+        vhost=None,
+    ):
+        """Set up parameters for a rabbitmq stream connection."""
+        super().__init__()
+        self.__parameters = {
+            "host": host,
+            "port": port,
+            "vhost": vhost,
+            "username": username,
+            "password": password,
+        }
+        self.stream_name = stream_name
+        self.__received_messages = []
+        self.__shutdown = asyncio.Event()
+        self.__closed = threading.Event()
+        self.__started = threading.Event()
+        self.__lock = threading.Lock()
+
+    async def __receive(self, msg: AMQPMessage, _: MessageContext) -> None:
+        """Call back for consuming messages."""
+        event = parse(json.loads(msg.body))
+        with self.__lock:
+            self.__received_messages.append(event.model_dump())
+
+    async def __consume_forever(self, consumer: Consumer):
+        """Consume messages indefinitely until shutdown signal is received."""
+        await consumer.subscribe(
+            stream=self.stream_name,
+            callback=self.__receive,
+            decoder=amqp_decoder,
+        )
+        if not self.__started.is_set():
+            self.__started.set()
+        await self.__shutdown.wait()  # Wait until shutdown signal is set
+
+    async def __wrap_consumer(self):
+        """Wrap the consumer in an async context manager to ensure proper cleanup."""
+        async with Consumer(**self.__parameters) as consumer:
+            await consumer.create_stream(self.stream_name, exists_ok=True)
+            try:
+                await self.__consume_forever(consumer)
+            finally:
+                await consumer.delete_stream(self.stream_name, missing_ok=True)
+                await consumer.close()
+
+    def run(self):
+        """Run the consumer, consuming messages from the stream until shutdown."""
+        try:
+            asyncio.run(self.__wrap_consumer())
+        finally:
+            self.__closed.set()
+
+    @property
+    def received_messages(self):
+        """Return the list of received messages."""
+        with self.__lock:
+            return self.__received_messages
+
+    def wait_start(self, timeout: float = 60.0):
+        """Wait for the consumer to start, meaning it has started consuming messages."""
+        if not self.__started.wait(timeout=timeout):
+            raise TimeoutError("Timeout while waiting for consumer to start")
+
+    def wait_closed(self, timeout: float = 60.0):
+        """Wait for the consumer to close, meaning it has stopped consuming messages."""
+        if not self.__closed.wait(timeout=timeout):
+            raise TimeoutError("Timeout while waiting for consumer to close")
+
+    def close(self):
+        """Close the consumer, signaling it to stop consuming messages."""
+        self.__shutdown.set()

--- a/tests/messaging/__init__.py
+++ b/tests/messaging/__init__.py
@@ -1,0 +1,16 @@
+# Copyright Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the messaging library."""

--- a/tests/messaging/test_publisher.py
+++ b/tests/messaging/test_publisher.py
@@ -65,10 +65,10 @@ class PublisherTests(unittest.TestCase):
     def tearDown(self):
         """Close the publisher and consumer after each test."""
         self.logger.info("TearDown: Closing publisher and consumer.")
-        if self.publisher.is_alive():
+        if self.publisher.is_publisher_alive():
             self.publisher.close(wait=True)
             self.publisher.join(timeout=5)
-            if self.publisher.is_alive():
+            if self.publisher.is_publisher_alive():
                 self.fail("Publisher thread did not terminate in tearDown.")
         self.consumer.close()
         self.consumer.join(timeout=5)
@@ -100,7 +100,7 @@ class PublisherTests(unittest.TestCase):
 
     def test_publisher_sends_and_consumer_receives(self):
         """Test that a message published by the Publisher is received by the Consumer."""
-        self.assertTrue(self.publisher.is_alive())
+        self.assertTrue(self.publisher.is_publisher_alive())
 
         testrun_id = "test_run_123"
         event = self._create_sample_event("Hello RabbitMQ Stream!")
@@ -201,7 +201,9 @@ class PublisherTests(unittest.TestCase):
         self.logger.info(
             "Verify that all messages were confirmed before the publisher fully closed."
         )
-        self.assertFalse(self.publisher.is_alive(), "Publisher should not be alive after close.")
+        self.assertFalse(
+            self.publisher.is_publisher_alive(), "Publisher should not be alive after close."
+        )
         self.assertEqual(
             self.publisher._Publisher__confirmed,
             num_messages,
@@ -233,7 +235,7 @@ class PublisherTests(unittest.TestCase):
     def test_publish_when_publisher_not_alive(self):
         """Test that publish raises RuntimeError if publisher is not started."""
         self.logger.info("Stop the publisher to test publish behavior when not alive.")
-        if self.publisher.is_alive():
+        if self.publisher.is_publisher_alive():
             self.publisher.close(wait=True)
             self.publisher.join(timeout=5)
 

--- a/tests/messaging/test_publisher.py
+++ b/tests/messaging/test_publisher.py
@@ -1,0 +1,248 @@
+# Copyright Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the messagebus publisher."""
+
+import logging
+import os
+import time
+import unittest
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from etos_lib.messaging.events import Message
+from etos_lib.messaging.publisher import Publisher
+from etos_lib.messaging.types import Log
+from tests.library.consumer import SimpleConsumer
+
+RABBITMQ_HOST = os.environ.get("RABBITMQ_HOST", "localhost")
+RABBITMQ_STREAM_PORT = int(os.environ.get("RABBITMQ_STREAM_PORT", 5552))
+RABBITMQ_USERNAME = os.environ.get("RABBITMQ_USERNAME", "guest")
+RABBITMQ_PASSWORD = os.environ.get("RABBITMQ_PASSWORD", "guest")
+RABBITMQ_VHOST = os.environ.get("RABBITMQ_VHOST", "/")
+# pylint: disable=protected-access
+
+
+class PublisherTests(unittest.TestCase):
+    """Integration tests for the messagebus Publisher."""
+
+    logger = logging.getLogger(__name__)
+
+    def setUp(self):
+        """Initialize the Publisher and a Consumer for each test."""
+        self.published_messages = []  # To store expected messages
+
+        parameters = {
+            "host": RABBITMQ_HOST,
+            "port": RABBITMQ_STREAM_PORT,
+            "vhost": RABBITMQ_VHOST,
+            "username": RABBITMQ_USERNAME,
+            "password": RABBITMQ_PASSWORD,
+        }
+        # Use a unique stream name for each test to avoid conflicts and ensure isolation
+        stream_name = str(uuid4())
+        self.consumer = SimpleConsumer(**parameters, stream_name=stream_name)
+        self.consumer.start()
+        self.consumer.wait_start(timeout=10)
+        self.publisher = Publisher(**parameters, stream_name=stream_name, ssl=False)
+        self.publisher.start()
+        self.publisher.wait_start(timeout=10)
+
+        self.logger.info("Publisher and Consumer setup complete for test.")
+
+    def tearDown(self):
+        """Close the publisher and consumer after each test."""
+        self.logger.info("TearDown: Closing publisher and consumer.")
+        if self.publisher.is_alive():
+            self.publisher.close(wait=True)
+            self.publisher.join(timeout=5)
+            if self.publisher.is_alive():
+                self.fail("Publisher thread did not terminate in tearDown.")
+        self.consumer.close()
+        self.consumer.join(timeout=5)
+        self.logger.info("TearDown complete.")
+
+    def _create_sample_event(self, message_text="Test log message"):
+        """Helper to create a sample event."""
+        now = datetime.now(timezone.utc)
+        log_data = Log(
+            message=message_text,
+            levelname="info",
+            name="test_logger",
+            datestring=now,
+        )
+        event = Message(id=time.time_ns(), data=log_data)
+        self.published_messages.append(event.model_dump())
+        return event
+
+    def _wait_for_message_confirmation(
+        self, publisher: Publisher, expected_count: int = 1, timeout: float = 5
+    ) -> bool:
+        """Helper to wait for a certain number of messages to be confirmed."""
+        timeout = time.time() + timeout
+        while time.time() < timeout:
+            time.sleep(0.1)
+            if publisher._Publisher__confirmed >= expected_count:
+                break
+        return publisher._Publisher__confirmed == expected_count
+
+    def test_publisher_sends_and_consumer_receives(self):
+        """Test that a message published by the Publisher is received by the Consumer."""
+        self.assertTrue(self.publisher.is_alive())
+
+        testrun_id = "test_run_123"
+        event = self._create_sample_event("Hello RabbitMQ Stream!")
+
+        self.logger.info("Publishing a message to the stream.")
+        self.publisher.publish(testrun_id, event)
+        self.logger.info("Published a message. Waiting for confirmation and receipt.")
+
+        self.logger.info("Waiting for publisher to confirm the message.")
+        self.assertTrue(
+            self._wait_for_message_confirmation(self.publisher, expected_count=1, timeout=5)
+        )
+
+        self.logger.info("Waiting for consumer to receive the published message.")
+        timeout = time.time() + 5
+        while len(self.consumer.received_messages) < 1 and time.time() < timeout:
+            time.sleep(0.1)
+
+        self.logger.info("Verifying that the consumer received the published message.")
+        self.assertEqual(
+            len(self.consumer.received_messages),
+            1,
+            "Consumer did not receive the published message.",
+        )
+        self.assertDictEqual(self.consumer.received_messages[0], self.published_messages[0])
+
+        self.logger.info("Successfully published and received one message.")
+
+    def test_publisher_sends_multiple_messages_and_consumer_receives_all(self):
+        """Test sending multiple messages and verifying all are received."""
+        num_messages = 5
+        testrun_id = "test_run_456"
+
+        self.logger.info("Publishing %d messages to test multiple message handling.", num_messages)
+        for i in range(num_messages):
+            event = self._create_sample_event(f"Multi-message {i + 1}")
+            self.publisher.publish(testrun_id, event)
+        self.logger.info(
+            "Published %d messages. Waiting for confirmation and receipt.", num_messages
+        )
+
+        self.logger.info("Waiting for publisher to confirm all messages.")
+        self.assertTrue(
+            self._wait_for_message_confirmation(
+                self.publisher, expected_count=num_messages, timeout=10
+            ),
+            "Publisher did not confirm all messages within the timeout.",
+        )
+
+        # Wait for the consumer to actually receive all messages
+        timeout = time.time() + 10
+        while len(self.consumer.received_messages) < num_messages and (time.time() < timeout):
+            time.sleep(0.1)
+
+        self.logger.info("Verifying that the consumer received all published messages.")
+        self.assertEqual(
+            len(self.consumer.received_messages),
+            num_messages,
+            "Consumer did not receive all published messages.",
+        )
+        self.assertEqual(self.consumer.received_messages, self.published_messages)
+
+        self.logger.info("Successfully published and received %d messages.", num_messages)
+
+    def test_publisher_close_waits_for_unpublished_events(self):
+        """
+        Test that closing the publisher waits for all currently unconfirmed messages
+        to be confirmed before shutting down.
+        """
+        testrun_id = "test_run_789"
+        num_messages = 3
+
+        self.logger.info(
+            "Publishing %d messages and then closing the publisher to test waiting for "
+            "unpublished events.",
+            num_messages,
+        )
+        for i in range(num_messages):
+            event = self._create_sample_event(f"Shutdown wait {i + 1}")
+            self.publisher.publish(testrun_id, event)
+            # Add a small delay to ensure messages are queued before attempting close
+            time.sleep(0.01)
+
+        self.logger.info(
+            "Published %d messages. Initiating close and waiting for all to confirm.", num_messages
+        )
+
+        self.logger.info(
+            "Verify that the publisher has the correct count of unconfirmed messages before close."
+        )
+        self.assertLessEqual(self.publisher._Publisher__confirmed, num_messages)
+        self.assertEqual(self.publisher._Publisher__unconfirmed, num_messages)
+
+        self.logger.info("Close the publisher to trigger waiting for unpublished events.")
+        self.publisher.close(wait=True)
+        self.publisher.wait_closed(timeout=10)  # Allow more time for network operations
+
+        self.logger.info(
+            "Verify that all messages were confirmed before the publisher fully closed."
+        )
+        self.assertFalse(self.publisher.is_alive(), "Publisher should not be alive after close.")
+        self.assertEqual(
+            self.publisher._Publisher__confirmed,
+            num_messages,
+            "Publisher did not confirm all messages before closing.",
+        )
+        self.assertEqual(
+            self.publisher._Publisher__unconfirmed,
+            num_messages,
+            "Unconfirmed counter mismatch after close.",
+        )
+
+        self.logger.info(
+            "Verify that the consumer received all messages published before shutdown."
+        )
+        timeout = time.time() + 5
+        while len(self.consumer.received_messages) < num_messages and (time.time() < timeout):
+            time.sleep(0.1)
+        self.assertEqual(
+            len(self.consumer.received_messages),
+            num_messages,
+            "Consumer did not receive all published messages during shutdown.",
+        )
+        self.assertEqual(self.consumer.received_messages, self.published_messages)
+
+        self.logger.info(
+            "Publisher successfully waited for all messages to confirm before closing."
+        )
+
+    def test_publish_when_publisher_not_alive(self):
+        """Test that publish raises RuntimeError if publisher is not started."""
+        self.logger.info("Stop the publisher to test publish behavior when not alive.")
+        if self.publisher.is_alive():
+            self.publisher.close(wait=True)
+            self.publisher.join(timeout=5)
+
+        event = self._create_sample_event()
+        self.logger.info("Attempting to publish a message when the publisher is not alive.")
+        with self.assertRaises(RuntimeError) as cm:
+            self.publisher.publish("test_id", event)
+        self.logger.info(
+            "Verifying that the correct exception was raised when publishing with a non-alive "
+            "publisher."
+        )
+        self.assertEqual(str(cm.exception), "Publisher is not alive")

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
 envlist = py3,black,pylint,pydocstyle
 
-# [testenv]
-# deps =
-#     -r{toxinidir}/test-requirements.txt
-# commands =
-#     pytest -s --log-format="%(levelname)s: %(message)s" {posargs}
+[testenv]
+deps =
+    -r{toxinidir}/test-requirements.txt
+commands =
+    pytest -s --log-format="%(levelname)s: %(message)s" {posargs}
 
 [testenv:black]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ envlist = py3,black,pylint,pydocstyle
 deps =
     black
 commands =
-    black --check --diff -l 100 .
+    black --check --diff .
 
 [testenv:pylint]
 deps =


### PR DESCRIPTION
<!--
Filling out the template is required.
Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
Any pull request must pass all automated tests and, if applicable, code style checks.
In addition the pull request must contain tests that cover any new code.
-->

### Applicable Issues
<!--
Reference any relevant issues here. Every pull request should refer to at least one
issue. For exemptions to this rule, see the [contribution guidelines](./CONTRIBUTING.md).
If an issue can be closed when the PR is merged, please use the
[standard notation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
to link the PR to the issue and make sure the latter is closed automatically when the PR
is merged.
-->
eiffel-community/etos#570

### Description of the Change
<!--
Describe the change proposed and its benefits. The maintainers must be able to
understand the design of your change from this description. If we can't get a good idea
of what the code will be doing from this description, the pull request may be closed at
the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not
be familiar with or have worked with the sources addressed by this PR recently, so
please walk us through the concepts. Provide special attention to breaking changes.
-->
The SSEv2 server will consume RabbitMQ streams instead of reading from the log listener (that listens to a regular RabbitMQ queue). Implement support for sending logs to both RabbitMQ queues and RabbitMQ streams.

Also added support to publish other events than messages on the messagebus

### Alternate Designs
<!--
Explain what other alternates were considered and why the proposed version was selected.
-->
I created this publisher using Go with a Go->CGo->Python wrapper before. It was quicker and a bit more simple in terms of client design, however I did not like creating bindings to Python like that and started investigating how to do this in Python only.

I also decided to keep the old RabbitMQ publisher for logs and we will continue to publish using both clients for a while until we have switched over to SSEv2 fully.

### Possible Drawbacks
<!-- Describe the possible side-effects or negative impacts of this change. -->
We have to register the publisher close method using the protected function `_register_atexit()` in threading, or else we cannot automatically close down the connection to RabbitMQ when we shut down the program.
Another fix for that is to force all users of the publisher to explicitly close it before shutting down but that does not align with our current design in the services.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
