### PR TITLE
Add a way to disable SSEv1

### DIFF
--- a/src/etos_lib/lib/debug.py
+++ b/src/etos_lib/lib/debug.py
@@ -23,7 +23,7 @@ from collections import deque
 from pathlib import Path
 
 
-class Debug:
+class Debug:  # pylint: disable=too-many-public-methods
     """Debug flags for ETOS."""
 
     __events_published = deque(maxlen=int(os.getenv("ETOS_PUBLISHED_EVENT_HISTORY_SIZE", "100")))

--- a/src/etos_lib/lib/debug.py
+++ b/src/etos_lib/lib/debug.py
@@ -19,8 +19,8 @@ DEPRECATION WARNING: Some parameters which don't belong here will be removed.
 """
 
 import os
-from pathlib import Path
 from collections import deque
+from pathlib import Path
 
 
 class Debug:
@@ -48,6 +48,11 @@ class Debug:
     def disable_sending_events(self):
         """Disable sending eiffel events."""
         return bool(os.getenv("ETOS_DISABLE_SENDING_EVENTS", None))
+
+    @property
+    def disable_ssev1(self) -> bool:
+        """Disable SSEv1 publisher."""
+        return bool(os.getenv("ETOS_DISABLE_SSEV1", None))
 
     @property
     def enable_sending_logs(self):

--- a/src/etos_lib/logging/logger.py
+++ b/src/etos_lib/logging/logger.py
@@ -153,7 +153,7 @@ def setup_rabbitmq_logging(log_filter: EtosFilter) -> None:
 
     # Backwards compatibility
     rabbitmq = RabbitMQLogPublisher(**Config().etos_rabbitmq_publisher_data(), routing_key=None)
-    if Debug().enable_sending_logs:
+    if Debug().enable_sending_logs and not Debug().disable_ssev1:
         rabbitmq.start()
         atexit.register(close_rabbit, rabbitmq)
 


### PR DESCRIPTION
<!--
Filling out the template is required.
Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
Any pull request must pass all automated tests and, if applicable, code style checks.
In addition the pull request must contain tests that cover any new code.
-->

### Applicable Issues
<!--
Reference any relevant issues here. Every pull request should refer to at least one
issue. For exemptions to this rule, see the [contribution guidelines](./CONTRIBUTING.md).
If an issue can be closed when the PR is merged, please use the
[standard notation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
to link the PR to the issue and make sure the latter is closed automatically when the PR
is merged.
-->
eiffel-community/etos#570

### Description of the Change
<!--
Describe the change proposed and its benefits. The maintainers must be able to
understand the design of your change from this description. If we can't get a good idea
of what the code will be doing from this description, the pull request may be closed at
the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not
be familiar with or have worked with the sources addressed by this PR recently, so
please walk us through the concepts. Provide special attention to breaking changes.
-->
This is needed for when we are starting to publish SSE events from the ETOS API, since it cannot publish to SSEv1 but it can publish to SSEv2

### Alternate Designs
<!--
Explain what other alternates were considered and why the proposed version was selected.
-->

### Possible Drawbacks
<!-- Describe the possible side-effects or negative impacts of this change. -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
