### PR TITLE
Default provider fields to empty string

### DIFF
--- a/src/etos_lib/kubernetes/schemas/testrun.py
+++ b/src/etos_lib/kubernetes/schemas/testrun.py
@@ -123,9 +123,9 @@ class Suite(BaseModel):
 class Providers(BaseModel):
     """Providers describes the providers to use for a testrun."""
 
-    executionSpace: Optional[str] = "default"
-    logArea: Optional[str] = "default"
-    iut: Optional[str] = "default"
+    executionSpace: Optional[str] = ""
+    logArea: Optional[str] = ""
+    iut: Optional[str] = ""
 
 
 class TestRunner(BaseModel):


### PR DESCRIPTION
### Applicable Issues

Related to https://github.com/eiffel-community/etos/issues/669

### Description of the Change

Change Providers model defaults from "default" to empty string so the testrun webhook can resolve default providers from labeled Provider CRDs. Companion change to https://github.com/eiffel-community/etos/pull/670 and https://github.com/eiffel-community/etos-api/pull/161.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com